### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Pass a table to the setup call with your configuration options.
     -- Jump to symbol under cursor but keep focus on outline window.
     peek_location = "o",
     -- Visit location in code and close outline immediately
-    goto_and_close = "<S-Cr>"
+    goto_and_close = "<S-Cr>",
     -- Change cursor position of outline window to match current location in code.
     -- "Opposite" of goto/peek_location.
     restore_location = "<C-g>",


### PR DESCRIPTION
Add missing comma after `goto_and_close = "<S-Cr>"` in the default config's keymaps

I noticed it because I copied and pasted the defaults, then used them as a template while setting up my config. 