### PR TITLE
use neovim core treesitter API instead of nvim-treesitter plugin

### DIFF
--- a/lua/outline/utils/jsx.lua
+++ b/lua/outline/utils/jsx.lua
@@ -96,15 +96,12 @@ function M.parse_ts(root, children, bufnr)
 end
 
 function M.get_symbols(bufnr)
-  local status, parsers = pcall(require, 'nvim-treesitter.parsers')
+  bufnr = bufnr or 0
 
+  local status, parser = pcall(vim.treesitter.get_parser, bufnr)
   if not status then
     return {}
   end
-
-  bufnr = bufnr or 0
-
-  local parser = parsers.get_parser(bufnr)
 
   if parser == nil then
     return {}


### PR DESCRIPTION
Hi,

Can you please look into this PR. 

It uses Neovim's core Treesitter API instead of the _nvim-treesitter_ plugin. The motivation behind this is that _nvim-treesitter_ will be rewritten (see: https://github.com/nvim-treesitter/nvim-treesitter/tree/main) and this will break the outline plugin because `nvim-treesitter.parsers.get_parser()` will be removed.

This should work with Neovim 0.9 or later. Maybe it would make sense to wrap this around an option.