### PR TITLE
[fix] - Fixing Coc symbol parsing bug

### DIFF
--- a/lua/outline/providers/coc.lua
+++ b/lua/outline/providers/coc.lua
@@ -76,7 +76,7 @@ function M.request_symbols(on_symbols, opts)
   vim.fn.call('CocActionAsync', {
     'documentSymbols',
     function(_, symbols)
-      on_symbols({ [1000000] = { result = convert_symbols(symbols) } }, opts)
+      on_symbols(convert_symbols(symbols), opts)
     end,
   })
 end


### PR DESCRIPTION
The plugin didn't work out of the box with coc.nvim, I had to change this line to make it work....

Not sure what was the initial role of `{ [1000000] = { result = ... } }`, but it was the source of the problem for me