### PR TITLE
fix(outline-window): no resize if split_command like "30vsplit"

### DIFF
--- a/lua/outline/view.lua
+++ b/lua/outline/view.lua
@@ -23,8 +23,11 @@ function View:setup_view(split_command)
   -- create a split
   vim.cmd(split_command)
 
-  -- resize to a % of the current window size
-  vim.cmd('vertical resize ' .. cfg.o.outline_window.width)
+  -- resize if split_command not specify width like "25vsplit"
+  if split_command:match("%d+") == nil then
+    -- resize to a % of the current window size
+    vim.cmd('vertical resize ' .. cfg.o.outline_window.width)
+  end
 
   -- get current (outline) window and attach our buffer to it
   self.win = vim.api.nvim_get_current_win()


### PR DESCRIPTION
This allows user to specify window width in `split_command`. Also fix #63.