### PR TITLE
Add support for vimdoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ https://github.com/hedyhli/outline.nvim/assets/50042066/88fbb3cf-27c1-4115-8a08-
 **Features**
 
 - Auto-updates items and highlight for current symbol as the cursor moves
-- Supports **JSX** (treesitter), **Markdown**, **Norg** (treesitter), in
-  addition to LSP, with other treesitter support coming soon
+- Supports **JSX** (treesitter), **Markdown**, **Norg** (treesitter), **Vimdoc**
+  (treesitter), in addition to LSP, with other treesitter support coming soon
 - Outline window opened for each tabpage
 - Symbol hierarchy UI with collapsible nodes and automatic collapsing based on
   cursor movements
@@ -361,7 +361,7 @@ Pass a table to the setup call with your configuration options.
   },
 
   providers = {
-    priority = { 'lsp', 'coc', 'markdown', 'norg' },
+    priority = { 'lsp', 'coc', 'markdown', 'norg', 'vimdoc' },
     -- Configuration for each provider (3rd party providers are supported)
     lsp = {
       -- Lsp client names to ignore

--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ The current list of tested providers are:
    - For JSX support, `javascript` parser for treesitter is required
 1. Markdown (no external requirements)
 1. Norg (requires `norg` parser for treesitter)
+1. Vimdoc (requires `vimdoc` parser for treesitter)
 
 External providers:
 - [Asciidoc](https://github.com/msr1k/outline-asciidoc-provider.nvim) (no external requirements)

--- a/doc/outline.txt
+++ b/doc/outline.txt
@@ -312,7 +312,7 @@ Show defaults ~
       },
     
       providers = {
-        priority = { 'lsp', 'coc', 'markdown', 'norg' },
+        priority = { 'lsp', 'coc', 'markdown', 'norg', 'vimdoc' },
         -- Configuration for each provider (3rd party providers are supported)
         lsp = {
           -- Lsp client names to ignore
@@ -435,10 +435,13 @@ A fallback is always used if the previous candidate returned a falsey value.
 
 PROVIDERS                                                  *outline-providers*
 
-The current list of tested providers are: 1. LSP (requires a suitable LSP
-server to be configured for the requested buffer) - For JSX support,
-`javascript` parser for treesitter is required 1. Markdown (no external
-requirements) 1. Norg (requires `norg` parser for treesitter)
+The current list of tested providers are:
+1. LSP (requires a suitable LSP server to be configured for the requested
+buffer)
+  - For JSX support, `javascript` parser for treesitter is required
+2. Markdown (no external requirements)
+3. Norg (requires `norg` parser for treesitter)
+4. Vimdoc (requires `vimdoc` parser for treesitter)
 
 External providers: - Asciidoc
 <https://github.com/msr1k/outline-asciidoc-provider.nvim> (no external

--- a/lua/outline/config.lua
+++ b/lua/outline/config.lua
@@ -90,7 +90,7 @@ M.defaults = {
     up_and_jump = '<C-k>',
   },
   providers = {
-    priority = { 'lsp', 'coc', 'markdown', 'norg' },
+    priority = { 'lsp', 'coc', 'markdown', 'norg', 'vimdoc'},
     lsp = {
       blacklist_clients = {},
     },

--- a/lua/outline/providers/vimdoc.lua
+++ b/lua/outline/providers/vimdoc.lua
@@ -1,0 +1,102 @@
+local M = {
+    name = 'vimdoc'
+}
+
+local LANG = 'vimdoc'
+
+---@param bufnr integer
+---@param _ table?
+---@return boolean
+function M.supports_buffer(bufnr, _)
+    local val = vim.api.nvim_get_option_value('ft', { buf = bufnr })
+    if val ~= 'help' then
+        return false
+    end
+
+    local ok, parser = pcall(vim.treesitter.get_parser, bufnr, LANG)
+    if not ok then
+        return false
+    end
+
+    M.parser = parser
+    return true
+end
+
+---@param on_symbols fun(symbols?:outline.ProviderSymbol[], opts?:table)
+---@param opts table
+function M.request_symbols(on_symbols, opts)
+    local rootNode = M.parser:parse()[1]:root()
+
+    local queryString = [[
+        [
+            (h1 (heading) @h1)
+            (h2 (heading) @h2)
+            (h3 (heading) @h3)
+            (tag) @tag
+        ]
+    ]]
+    local query
+    if _G._outline_nvim_has[9] then
+        query = vim.treesitter.query.parse(LANG, queryString)
+    else
+        ---@diagnostic disable-next-line: deprecated
+        query = vim.treesitter.query.parse_query(LANG, queryString)
+    end
+
+    local captureLevelMap = { h1 = 1, h2 = 2, h3 = 3, tag = 4 }
+    local kindMap = { h1 = 15, h2 = 15, h3 = 15, tag = 13 }
+
+    local root = { children = {}, level = 0, parent = nil }
+    local current = root
+
+    for id, node, _, _ in query:iter_captures(rootNode, 0) do
+        local capture = query.captures[id]
+        local captureLevel = captureLevelMap[capture]
+
+        local row1, col1, row2, col2 = node:range()
+        local captureString = vim.api.nvim_buf_get_text(0, row1, col1, row2, col2, {})[1]
+
+        while captureLevel <= current.level do
+            current = current.parent
+            assert(current ~= nil)
+        end
+
+        local new = {
+            kind = kindMap[capture],
+            name = captureString,
+            -- Treesitter includes the last newline in the end range which spans
+            -- until the next heading, so we -1
+            -- TODO: This fix can be removed when we let highlight_hovered_item
+            -- account for current column position in addition to the line.
+            -- FIXME: By the way the end character should be the EOL
+            selectionRange = {
+                start = { character = col1, line = row1 },
+                ['end'] = { character = col2, line = row2 - 1 },
+            },
+            range = {
+                start = { character = col1, line = row1 },
+                ['end'] = { character = col2, line = row2 - 1 },
+            },
+            children = {},
+
+            parent = current,
+            level = captureLevel,
+        }
+
+        table.insert(current.children, new)
+        current = new
+    end
+
+    local function removeExtraAttrs(node)
+        for _, child in pairs(node.children) do
+            removeExtraAttrs(child)
+        end
+        node.parent = nil
+        node.level = nil
+    end
+    removeExtraAttrs(root)
+
+    on_symbols(root.children, opts)
+end
+
+return M

--- a/lua/outline/providers/vimdoc.lua
+++ b/lua/outline/providers/vimdoc.lua
@@ -1,8 +1,7 @@
-local M = {
-  name = 'vimdoc'
-}
+local symbols = require('outline.symbols')
 
 local LANG = 'vimdoc'
+local M = { name = LANG }
 
 ---@param bufnr integer
 ---@param _ table?
@@ -44,7 +43,10 @@ function M.request_symbols(on_symbols, opts)
   end
 
   local captureLevelMap = { h1 = 1, h2 = 2, h3 = 3, tag = 4 }
-  local kindMap = { h1 = 15, h2 = 15, h3 = 15, tag = 13 }
+
+  local strKind = symbols.str_to_kind['String']
+  local varKind = symbols.str_to_kind['Variable']
+  local kindMap = { h1 = strKind, h2 = strKind, h3 = strKind, tag = varKind }
 
   local root = { children = {}, level = 0, parent = nil }
   local current = root

--- a/lua/outline/providers/vimdoc.lua
+++ b/lua/outline/providers/vimdoc.lua
@@ -1,5 +1,5 @@
 local M = {
-    name = 'vimdoc'
+  name = 'vimdoc'
 }
 
 local LANG = 'vimdoc'
@@ -8,95 +8,95 @@ local LANG = 'vimdoc'
 ---@param _ table?
 ---@return boolean
 function M.supports_buffer(bufnr, _)
-    local val = vim.api.nvim_get_option_value('ft', { buf = bufnr })
-    if val ~= 'help' then
-        return false
-    end
+  local val = vim.api.nvim_get_option_value('ft', { buf = bufnr })
+  if val ~= 'help' then
+    return false
+  end
 
-    local ok, parser = pcall(vim.treesitter.get_parser, bufnr, LANG)
-    if not ok then
-        return false
-    end
+  local ok, parser = pcall(vim.treesitter.get_parser, bufnr, LANG)
+  if not ok then
+    return false
+  end
 
-    M.parser = parser
-    return true
+  M.parser = parser
+  return true
 end
 
 ---@param on_symbols fun(symbols?:outline.ProviderSymbol[], opts?:table)
 ---@param opts table
 function M.request_symbols(on_symbols, opts)
-    local rootNode = M.parser:parse()[1]:root()
+  local rootNode = M.parser:parse()[1]:root()
 
-    local queryString = [[
-        [
-            (h1 (heading) @h1)
-            (h2 (heading) @h2)
-            (h3 (heading) @h3)
-            (tag) @tag
-        ]
-    ]]
-    local query
-    if _G._outline_nvim_has[9] then
-        query = vim.treesitter.query.parse(LANG, queryString)
-    else
-        ---@diagnostic disable-next-line: deprecated
-        query = vim.treesitter.query.parse_query(LANG, queryString)
+  local queryString = [[
+    [
+      (h1 (heading) @h1)
+      (h2 (heading) @h2)
+      (h3 (heading) @h3)
+      (tag) @tag
+    ]
+  ]]
+  local query
+  if _G._outline_nvim_has[9] then
+    query = vim.treesitter.query.parse(LANG, queryString)
+  else
+    ---@diagnostic disable-next-line: deprecated
+    query = vim.treesitter.query.parse_query(LANG, queryString)
+  end
+
+  local captureLevelMap = { h1 = 1, h2 = 2, h3 = 3, tag = 4 }
+  local kindMap = { h1 = 15, h2 = 15, h3 = 15, tag = 13 }
+
+  local root = { children = {}, level = 0, parent = nil }
+  local current = root
+
+  for id, node, _, _ in query:iter_captures(rootNode, 0) do
+    local capture = query.captures[id]
+    local captureLevel = captureLevelMap[capture]
+
+    local row1, col1, row2, col2 = node:range()
+    local captureString = vim.api.nvim_buf_get_text(0, row1, col1, row2, col2, {})[1]
+
+    while captureLevel <= current.level do
+      current = current.parent
+      assert(current ~= nil)
     end
 
-    local captureLevelMap = { h1 = 1, h2 = 2, h3 = 3, tag = 4 }
-    local kindMap = { h1 = 15, h2 = 15, h3 = 15, tag = 13 }
+    local new = {
+      kind = kindMap[capture],
+      name = captureString,
+      -- Treesitter includes the last newline in the end range which spans
+      -- until the next heading, so we -1
+      -- TODO: This fix can be removed when we let highlight_hovered_item
+      -- account for current column position in addition to the line.
+      -- FIXME: By the way the end character should be the EOL
+      selectionRange = {
+        start = { character = col1, line = row1 },
+        ['end'] = { character = col2, line = row2 - 1 },
+      },
+      range = {
+        start = { character = col1, line = row1 },
+        ['end'] = { character = col2, line = row2 - 1 },
+      },
+      children = {},
 
-    local root = { children = {}, level = 0, parent = nil }
-    local current = root
+      parent = current,
+      level = captureLevel,
+    }
 
-    for id, node, _, _ in query:iter_captures(rootNode, 0) do
-        local capture = query.captures[id]
-        local captureLevel = captureLevelMap[capture]
+    table.insert(current.children, new)
+    current = new
+  end
 
-        local row1, col1, row2, col2 = node:range()
-        local captureString = vim.api.nvim_buf_get_text(0, row1, col1, row2, col2, {})[1]
-
-        while captureLevel <= current.level do
-            current = current.parent
-            assert(current ~= nil)
-        end
-
-        local new = {
-            kind = kindMap[capture],
-            name = captureString,
-            -- Treesitter includes the last newline in the end range which spans
-            -- until the next heading, so we -1
-            -- TODO: This fix can be removed when we let highlight_hovered_item
-            -- account for current column position in addition to the line.
-            -- FIXME: By the way the end character should be the EOL
-            selectionRange = {
-                start = { character = col1, line = row1 },
-                ['end'] = { character = col2, line = row2 - 1 },
-            },
-            range = {
-                start = { character = col1, line = row1 },
-                ['end'] = { character = col2, line = row2 - 1 },
-            },
-            children = {},
-
-            parent = current,
-            level = captureLevel,
-        }
-
-        table.insert(current.children, new)
-        current = new
+  local function removeExtraAttrs(node)
+    for _, child in pairs(node.children) do
+      removeExtraAttrs(child)
     end
+    node.parent = nil
+    node.level = nil
+  end
+  removeExtraAttrs(root)
 
-    local function removeExtraAttrs(node)
-        for _, child in pairs(node.children) do
-            removeExtraAttrs(child)
-        end
-        node.parent = nil
-        node.level = nil
-    end
-    removeExtraAttrs(root)
-
-    on_symbols(root.children, opts)
+  on_symbols(root.children, opts)
 end
 
 return M

--- a/lua/outline/providers/vimdoc.lua
+++ b/lua/outline/providers/vimdoc.lua
@@ -3,7 +3,6 @@ local M = {
 }
 
 local LANG = 'vimdoc'
-local MAX_LINES_COUNT = 1000000000
 
 ---@param bufnr integer
 ---@param _ table?
@@ -103,8 +102,9 @@ function M.request_symbols(on_symbols, opts)
     current = new
   end
 
+  local lineCount = vim.api.nvim_buf_line_count(0)
   while current.level > 0 do
-    updateRangeEnd(current, MAX_LINES_COUNT)
+    updateRangeEnd(current, lineCount)
     current = current.parent
     assert(current ~= nil)
   end

--- a/lua/outline/sidebar.lua
+++ b/lua/outline/sidebar.lua
@@ -340,7 +340,7 @@ function Sidebar:__refresh()
   end
   local ft = vim.api.nvim_buf_get_option(buf, 'ft')
   local listed = vim.api.nvim_buf_get_option(buf, 'buflisted')
-  if ft == 'OutlineHelp' or not listed then
+  if not (ft == 'help' or listed) then
     return
   end
   self.provider, self.provider_info = providers.find_provider()


### PR DESCRIPTION
I've added Vimdoc support, the implementation is very similar to that of Norg's. I included headings and tags in the outline, just headings provide very little information.

There seem to be quite a lot of edge cases that could be improved. For example, sometimes there are empty headings or headings that are not actual document headings but table headings. Sometimes there are multiple tags in one line, sometimes in multiple lines (but they refer to the same thing). The formatting seems quite inconsistent, even in the builtin documentation (e.g. the main page marks modeline as heading, other pages seem to get it right...). We could come up with some heuristics for the most common cases, for now I ignored all that.

Example below. 

<img width="1800" alt="image" src="https://github.com/hedyhli/outline.nvim/assets/12835846/52a168d7-b3e0-423b-a1fa-09eeeb50d4b4">

I used `Variable` kind for tags so that they can be easily filtered out.

I've encountered on issue, not sure if my change caused it. When there is a window with help file open and another with, for example, a lua file then the outline sidebar will show outline for the lua file always. For some reason the outline for help files seems to work only for one file and if there is another buffer in the same tab it will take over. Even switching between two help files won't work, the first one will be always shown in the sidebar. Other filetypes seem to work fine. I can try to debug that, but maybe someone has an idea what could be the reason?

Resolves: #34 