### PR TITLE
Improve preview window size calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,12 +300,17 @@ Pass a table to the setup call with your configuration options.
     -- below.
     open_hover_on_preview = false,
     width = 50,     -- Percentage or integer of columns
-    min_width = 50, -- This is the number of columns
+    min_width = 50, -- Minimum number of columns
     -- Whether width is relative to the total width of nvim.
     -- When relative_width = true, this means take 50% of the total
     -- screen width for preview window, ensure the result width is at least 50
     -- characters wide.
     relative_width = true,
+    height = 50,     -- Percentage or integer of lines
+    min_height = 10, -- Minimum number of lines
+    -- Similar to relative_width, except the height is relative to the outline
+    -- window's height.
+    relative_height = true,
     -- Border option for floating preview window.
     -- Options include: single/double/rounded/solid/shadow or an array of border
     -- characters.

--- a/doc/outline.txt
+++ b/doc/outline.txt
@@ -257,11 +257,11 @@ Show defaults ~
         -- screen width for preview window, ensure the result width is at least 50
         -- characters wide.
         relative_width = true,
-	height = 50,     -- Percentage or integer of lines
-	min_height = 10, -- Minimum number of lines
-	-- Similar to relative_width, except the height is relative to the outline
-	-- window's height.
-	relative_height = true,
+        height = 50,     -- Percentage or integer of lines
+        min_height = 10, -- Minimum number of lines
+        -- Similar to relative_width, except the height is relative to the outline
+        -- window's height.
+        relative_height = true,
         -- Border option for floating preview window.
         -- Options include: single/double/rounded/solid/shadow or an array of border
         -- characters.

--- a/doc/outline.txt
+++ b/doc/outline.txt
@@ -257,6 +257,11 @@ Show defaults ~
         -- screen width for preview window, ensure the result width is at least 50
         -- characters wide.
         relative_width = true,
+	height = 50,     -- Percentage or integer of lines
+	min_height = 10, -- Minimum number of lines
+	-- Similar to relative_width, except the height is relative to the outline
+	-- window's height.
+	relative_height = true,
         -- Border option for floating preview window.
         -- Options include: single/double/rounded/solid/shadow or an array of border
         -- characters.

--- a/lua/outline/config.lua
+++ b/lua/outline/config.lua
@@ -53,7 +53,9 @@ M.defaults = {
     width = 50,
     min_width = 50,
     relative_width = true,
+    height = 50,
     min_height = 10,
+    relative_height = true,
     border = 'single',
     open_hover_on_preview = false,
     winhl = 'NormalFloat:',
@@ -162,16 +164,31 @@ function M.get_window_width()
   return M.o.outline_window.width
 end
 
-function M.get_preview_width()
-  if M.o.preview_window.relative_width then
+---@param conf table
+function M.get_preview_width(conf)
+  if conf.relative_width then
     local relative_width = math.max(
-      math.ceil(vim.o.columns * (M.o.preview_window.width / 100)),
-      M.o.preview_window.min_width
+      math.ceil(vim.o.columns * (conf.width / 100)),
+      conf.min_width
     )
-
     return relative_width
   else
-    return M.o.preview_window.width
+    return conf.width
+  end
+end
+
+---@param conf table
+---@param outline_height integer
+---@return integer
+function M.get_preview_height(conf, outline_height)
+  if conf.relative_height then
+    local relative_height = math.max(
+      math.ceil(outline_height * (conf.height / 100)),
+      conf.min_height
+    )
+    return relative_height
+  else
+    return conf.height
   end
 end
 
@@ -318,8 +335,6 @@ function M.resolve_config()
       M.o.keymaps[action] = { keys }
     end
   end
-  ----- PREVIEW -----
-  M.o.preview_window.width = M.get_preview_width()
   ----- WINDOW -----
   M.o.outline_window.width = M.get_window_width()
   ----- LSP BLACKLIST -----

--- a/lua/outline/preview.lua
+++ b/lua/outline/preview.lua
@@ -1,3 +1,5 @@
+local cfg = require('outline.config')
+
 -- A floating window to preview the location of a symbol from the outline.
 -- Classical preview reads entire lines into a new buffer for preview. Live
 -- preview sets the buffer of floating window to the code buffer, which allows
@@ -95,8 +97,8 @@ local function update_size(self)
   end
 
   self.outline_height = vim.api.nvim_win_get_height(self.s.view.win)
-  self.width = self.conf.width
-  self.height = math.max(math.ceil(self.outline_height / 2), self.conf.min_height)
+  self.width = cfg.get_preview_width(self.conf)
+  self.height = cfg.get_preview_height(self.conf, self.outline_height)
   local row = calc_row(self)
   local col = calc_col(self)
   vim.api.nvim_win_set_config(self.win, {
@@ -117,8 +119,8 @@ function Preview:create()
     end,
   })
   self.outline_height = vim.api.nvim_win_get_height(self.s.view.win)
-  self.width = self.conf.width
-  self.height = math.max(math.ceil(self.outline_height / 2), self.conf.min_height)
+  self.width = cfg.get_preview_width(self.conf)
+  self.height = cfg.get_preview_height(self.conf, self.outline_height)
   self.win = vim.api.nvim_open_win(self.buf, false, {
     relative = 'editor',
     height = self.height,
@@ -221,8 +223,8 @@ function LivePreview:create()
   self.codewin = self.s.code.win
   self.initial_cursorline = vim.api.nvim_win_get_option(self.s.code.win, 'cursorline')
   self.outline_height = vim.api.nvim_win_get_height(self.s.view.win)
-  self.width = self.conf.width
-  self.height = math.max(math.ceil(self.outline_height / 2), self.conf.min_height)
+  self.width = cfg.get_preview_width(self.conf)
+  self.height = cfg.get_preview_height(self.conf, self.outline_height)
   self.win = vim.api.nvim_open_win(self.s.code.buf, false, {
     relative = 'editor',
     height = self.height,


### PR DESCRIPTION
- Stop caching width and height of the preview window which prevented the size to be adjusted after the nvim window's resize.
- Add config options for height to match width options.
- Mention height config options in readme and vimdoc (previously missing).