### PR TITLE
Add mouse support

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,18 @@ Pass a table to the setup call with your configuration options.
     -- j/k/<down>/<up>.
     down_and_jump = '<C-j>',
     up_and_jump = '<C-k>',
+    --
+    -- Below are special keymaps for use with a mouse. The default configuration is tested.
+    -- Other configurations may have weird edge cases and/or work poorly with other mouse
+    -- actions, such as selection extension on right click, pop-up menu on right click and other.
+    --
+    -- Move cursor to line under mouse cursor in Outline window. Does not jump to the location in code.
+    -- Equivalent to navigating with 'j', 'k', etc.
+    mouse_select = '<LeftMouse>',
+    -- Jump to symbol under mouse cursor. Equivalent to 'peek_location' keymap.
+    mouse_peek = '<RightMouse>',
+    -- Toggle fold with a mouse. By default, with a double left click.
+    mouse_fold_toggle = '<2-LeftMouse>',
   },
 
   providers = {

--- a/lua/outline/config.lua
+++ b/lua/outline/config.lua
@@ -88,6 +88,9 @@ M.defaults = {
     fold_reset = 'R',
     down_and_jump = '<C-j>',
     up_and_jump = '<C-k>',
+    mouse_select = '<LeftMouse>',
+    mouse_peek = '<RightMouse>',
+    mouse_fold_toggle = '<2-LeftMouse>',
   },
   providers = {
     priority = { 'lsp', 'coc', 'markdown', 'norg' },


### PR DESCRIPTION
I know that mouse is not super popular with vim users. I find it occasionally useful, though.

By default, left click selects a field, double left click toggles fold and right click peeks location.

I found that a lot of keymaps configurations may have issues. For example, with some configs it's easy to unintentionally select text, in others it might be easy to open the popup menu (with right click) by accident, some didn't work for me at all. Another gotcha is that double click always triggers single click mapping. There is more but I don't remember all the details right now. "Goto location" is not implemented (only "peek location") because of similar issues as mentioned above.

That being said I think that it works reasonably well. It just isn't as flexible as it potentially could be.

Here is what it looks like in practice:
![outline_mouse](https://github.com/user-attachments/assets/889bb681-3b20-46ee-9100-7d3901fb4112)