### PR TITLE
fixed a bug in capturing guicursor style using regex

### DIFF
--- a/lua/outline/sidebar.lua
+++ b/lua/outline/sidebar.lua
@@ -255,7 +255,8 @@ function Sidebar:update_cursor_style()
 
   -- Set cursor color to CursorLine in normal mode
   if hide_cursor then
-    local cur = vim.o.guicursor:match('n.-:(.-)[-,]')
+    -- local cur = vim.o.guicursor:match('n.-:(.-)[-,]')
+    local cur = vim.o.guicursor:match('n.-:([^,]+)')
     vim.opt.guicursor:append('n:' .. cur .. '-Cursorline')
   end
 end


### PR DESCRIPTION
There's a bug in sidebar.lua:258, the regex pattern matches nothing when `vim.o.guicursor = 'n-v-i-c:block'` (or other similar patterns), hence causes a nil access error. I changed the regex pattern to `'n.-:([^,]+)'`. 