### PR TITLE
feat: add view.filter option

### DIFF
--- a/lua/outline/sidebar.lua
+++ b/lua/outline/sidebar.lua
@@ -340,7 +340,7 @@ function Sidebar:__refresh()
   end
   local ft = vim.api.nvim_buf_get_option(buf, 'ft')
   local listed = vim.api.nvim_buf_get_option(buf, 'buflisted')
-  if ft == 'OutlineHelp' or not listed then
+  if ft == 'OutlineHelp' or not (listed or ft == 'help') then
     return
   end
   self.provider, self.provider_info = providers.find_provider()


### PR DESCRIPTION
Because outline.nvim defaults to ignoring `nobuflisted` buffers, an option hook needs to be added for user customization.

After adding following options and `'epheien/outline-treesitter-provider.nvim'` dependency, `outline.nvim` can support help (vimdoc) filetype.
```lua
{
  view = {
    filter = function(buf)
      local ft = vim.bo[buf].filetype
      if ft == 'qf' then return false end
      return vim.bo[buf].buflisted or ft == 'help'
    end,
  },
}
```

refer https://github.com/hedyhli/outline.nvim/issues/34

<img width="952" alt="Xnip2024-12-27_09-23-54" src="https://github.com/user-attachments/assets/53c06cb2-2688-47ef-9cfe-dd2fdef13152" />