### PR TITLE
feat: icon_fetcher adds symbol parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -920,6 +920,24 @@ symbols = {
 }
 ```
 
+  The `icon_fetcher` function may also accept a third parameter, the symbol
+  which type is outline.Symbol. Provider can add extra info to symbol.
+  For example, access specifier information can be added at the icon location.
+
+```lua
+symbols = {
+  icon_fetcher = function(kind, bufnr, symbol)
+    local access_icons = { public = '○', protected = '◉', private = '●' }
+    local icon = require('outline.config').o.symbols.icons[kind].icon
+    -- ctags provider add `access` key
+    if symbol and symbol.access then
+      return icon .. ' ' .. access_icons[symbol.access]
+    end
+    return icon
+  end,
+}
+```
+
   See [this section](#custom-icons) for other examples of this function.
 
 - You can customize the split command used for creating the outline window split

--- a/lua/outline/parser.lua
+++ b/lua/outline/parser.lua
@@ -37,7 +37,7 @@ local function parse_result(result, depth, hierarchy, parent, bufnr)
       local node = {
         deprecated = value.deprecated,
         kind = value.kind,
-        icon = symbols.icon_from_kind(value.kind, bufnr),
+        icon = symbols.icon_from_kind(value.kind, bufnr, value),
         name = value.name or value.text,
         detail = value.detail,
         line = selectionRange.start.line,

--- a/lua/outline/symbols.lua
+++ b/lua/outline/symbols.lua
@@ -52,8 +52,9 @@ local lspkind = {
 
 ---@param kind string|integer
 ---@param bufnr integer
+---@param symbol? outline.Symbol
 ---@return string icon
-function M.icon_from_kind(kind, bufnr)
+function M.icon_from_kind(kind, bufnr, symbol)
   local kindstr = kind
   if type(kind) ~= 'string' then
     kindstr = M.kinds[kind]
@@ -63,7 +64,7 @@ function M.icon_from_kind(kind, bufnr)
   end
 
   if type(cfg.o.symbols.icon_fetcher) == 'function' then
-    local icon = cfg.o.symbols.icon_fetcher(kindstr, bufnr)
+    local icon = cfg.o.symbols.icon_fetcher(kindstr, bufnr, symbol)
     -- Allow returning empty string
     if icon then
       return icon


### PR DESCRIPTION
For example, access control information can be added at the icon location.
However, it is known that clangd currently does not return access spec information, while ctags can.

```lua
local access_icons = {
  public = '○',
  protected = '◉',
  private = '●',
}
    ...
    icon_fetcher = function(kindstr, bufnr, symbol) ---@diagnostic disable-line
      local cfg = require('outline.config')
      local icon = cfg.o.symbols.icons[kindstr].icon
      if symbol and symbol.access then
        return icon .. ' ' .. access_icons[symbol.access]
      end
      return icon
    end,
    ...
```