### PR TITLE
feat: add to jumplist before goto location

### DIFF
--- a/lua/outline/sidebar.lua
+++ b/lua/outline/sidebar.lua
@@ -392,6 +392,9 @@ function Sidebar:__goto_location(change_focus)
     return
   end
 
+  -- XXX: There will be strange problems when using `nvim_buf_set_mark()`.
+  vim.fn.win_execute(self.code.win, "normal! m'")
+
   vim.api.nvim_win_set_cursor(self.code.win, { node.line + 1, node.character })
 
   if cfg.o.outline_window.center_on_jump then


### PR DESCRIPTION
Because the API exported by outline.nvim is difficult to obtain the window ID of the code (code.win), it is hard for users to implement a jumplist before jumping.