### PR TITLE
feat: Add configuration for no providers message

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ Pass a table to the setup call with your configuration options.
     -- See :help 'winhl'
     -- To change background color to "CustomHl" for example, use "Normal:CustomHl".
     winhl = '',
+    -- Message displayed when there are no providers avialable.
+    no_provider_message = 'No supported provider...'
   },
 
   outline_items = {

--- a/lua/outline/config.lua
+++ b/lua/outline/config.lua
@@ -46,6 +46,7 @@ M.defaults = {
     winhl = '',
     jump_highlight_duration = 400,
     center_on_jump = true,
+    no_provider_message = 'No supported provider...',
   },
   preview_window = {
     live = false,

--- a/lua/outline/sidebar.lua
+++ b/lua/outline/sidebar.lua
@@ -371,7 +371,7 @@ end
 -- stylua: ignore end
 
 function Sidebar:no_providers_ui()
-  self.view:rewrite_lines({ 'No supported provider...' })
+  self.view:rewrite_lines({ cfg.o.outline_window.no_provider_message })
   vim.api.nvim_win_set_cursor(self.view.win, { 1, 0 })
 end
 


### PR DESCRIPTION
I am using outline.nvim as my permanent sidebar and I am constantly annoyed by this message always displaying when I am openning any non lsp related buffer e.g. picker or fugitive window

<img width="1335" alt="Image" src="https://github.com/user-attachments/assets/09384652-b8d0-4b57-8e0e-07a6e73b65fc" />

With this config I can set `no_provider_message` to empty string and enjoy a clean sidebar if there is nothing to show:

<img width="1437" alt="Image" src="https://github.com/user-attachments/assets/f411b995-c0ec-4d06-980f-bad17f490bf5" />