### PR TITLE
feat: add symbols filtering via picker

### DIFF
--- a/lua/outline/config.lua
+++ b/lua/outline/config.lua
@@ -91,7 +91,10 @@ M.defaults = {
     fold_reset = 'R',
     down_and_jump = '<C-j>',
     up_and_jump = '<C-k>',
+
+    filter_symbols = 'F',
   },
+  picker = 'default', -- "default, fzf-lua"
   providers = {
     priority = { 'lsp', 'coc', 'markdown', 'norg', 'man' },
     lsp = {

--- a/lua/outline/pickers/default.lua
+++ b/lua/outline/pickers/default.lua
@@ -1,0 +1,14 @@
+local Util = require('outline.pickers.utils')
+
+return function(opts, contents)
+  vim.ui.select(contents, { prompt = 'Filter Symbols> ' }, function(choice)
+    if not choice then
+      return
+    end
+    local filters = {}
+    if choice ~= Util.all_kind then
+      table.insert(filters, Util.strip_whitespace(choice))
+    end
+    opts.set_filters(filters)
+  end)
+end

--- a/lua/outline/pickers/fzf-lua.lua
+++ b/lua/outline/pickers/fzf-lua.lua
@@ -1,0 +1,94 @@
+local Util = require('outline.pickers.utils')
+local fzf = require('fzf-lua')
+
+local function format_title(str, icon, icon_hl)
+  return {
+    { ' ', 'FzfLuaTitle' },
+    { (icon and icon .. ' ' or ''), icon_hl or 'FzfLuaTitle' },
+    { str, 'FzfLuaTitle' },
+    { ' ', 'FzfLuaTitle' },
+  }
+end
+
+local function get_width_and_height(contents)
+  local max_height = 30
+  local max_width = 50
+
+  local height = #contents + 1
+  local width = 1
+
+  for _, ctx in pairs(contents) do
+    if width < #ctx then
+      width = #ctx
+    end
+  end
+
+  local win_height = max_height < height and max_height or height
+  local win_width = max_width > width and max_width or width
+
+  return {
+    win_height = win_height,
+    win_width = win_width,
+    width_str = width,
+  }
+end
+
+return function(opts, contents)
+  local win_opts = get_width_and_height(contents)
+
+  local entry_str = {}
+  for _, symbol in pairs(contents) do
+    if symbol ~= Util.all_kind then
+      local kind = opts.o.symbols.icons
+      if kind[symbol] then
+        local get_icon = Util.pad_string(kind[symbol].icon, 5)
+        local icon_hl = fzf.utils.ansi_from_hl(kind[symbol].hl, get_icon)
+        entry_str[#entry_str + 1] = string.format('%s %s', icon_hl, Util.strip_whitespace(symbol))
+      end
+    else
+      entry_str[#entry_str + 1] = symbol
+    end
+  end
+
+  fzf.fzf_exec(entry_str, {
+    ---@diagnostic disable: missing-fields
+    ---@type fzf-lua.config.Winopts
+    winopts = {
+      title = format_title('Filter Symbols', ' '),
+      width = win_opts.win_width,
+      height = win_opts.win_height,
+      col = 0.50,
+      row = 0.50,
+    },
+    actions = {
+      ['default'] = function(selected, _)
+        if not selected then
+          return
+        end
+
+        local filters = {}
+
+        if #selected == 1 then
+          local sel = selected[1]
+          if sel ~= Util.all_kind then
+            local str_e = fzf.utils.strip_ansi_coloring(sel)
+            local mtch_str = str_e:match('[a-zA-Z].*$')
+            if mtch_str then
+              table.insert(filters, mtch_str)
+            end
+          end
+        else
+          for _, sel in ipairs(selected) do
+            local str_e = fzf.utils.strip_ansi_coloring(sel)
+            local mtch_str = str_e:match('[a-zA-Z].*$')
+            if mtch_str then
+              table.insert(filters, mtch_str)
+            end
+          end
+        end
+
+        opts.set_filters(filters)
+      end,
+    },
+  })
+end

--- a/lua/outline/pickers/init.lua
+++ b/lua/outline/pickers/init.lua
@@ -1,0 +1,68 @@
+local util = require('outline.pickers.utils')
+local M = {}
+
+local function default_picker()
+  return 'default'
+end
+
+---@param picker_name string?
+local function get_picker(picker_name)
+  picker_name = picker_name or ''
+  local ok_picker, _ = pcall(require, picker_name)
+  if not ok_picker then
+    picker_name = picker_name
+  end
+
+  if util.is_blank(picker_name) then
+    picker_name = default_picker()
+  end
+
+  local ok, p = pcall(require, string.format('outline.pickers.%s', picker_name))
+  if not ok then
+    vim.notify(
+      string.format('Picker `%s` has not been implemented yet', picker_name),
+      vim.log.levels.ERROR
+    )
+    return
+  end
+
+  return p
+end
+
+---@param sidebar outline.Sidebar
+function M.select_symbols(cfg_symbols, sidebar)
+  local p = get_picker(cfg_symbols.o.picker)
+
+  local contents = util.get_contents_symbols(cfg_symbols)
+  if not contents or #contents == 0 then
+    return
+  end
+
+  ---@param sel table|nil
+  cfg_symbols.set_filters = function(sel)
+    if #sel == 0 then
+      sel = nil
+    end
+
+    cfg_symbols.o.symbols.filter = sel
+    cfg_symbols.o.outline_window.width = 25
+    cfg_symbols.setup(vim.tbl_deep_extend('force', {}, cfg_symbols.defaults, cfg_symbols.o or {}))
+
+    if sidebar.view:is_open() and sidebar:has_code_win() then
+      sidebar:close()
+    end
+
+    -- wait some time to avoid buffer-name conflict
+    vim.wait(1500, function()
+      return sidebar.view:is_open()
+    end)
+
+    sidebar:open()
+  end
+
+  if p then
+    p(cfg_symbols, contents)
+  end
+end
+
+return M

--- a/lua/outline/pickers/utils.lua
+++ b/lua/outline/pickers/utils.lua
@@ -1,0 +1,65 @@
+local M = {}
+
+M.all_kind = 'All'
+
+function M.is_blank(s)
+  return (
+    s == nil
+    or s == vim.NIL
+    or (type(s) == 'string' and string.match(s, '%S') == nil)
+    or (type(s) == 'table' and next(s) == nil)
+  )
+end
+
+---@return string[]|nil
+function M.get_contents_symbols(opts)
+  if not opts.o.symbols.icons then
+    vim.notify('simbols.icons not found!', vim.log.levels.ERROR)
+    return
+  end
+
+  local symbols_items = {}
+
+  for key, _ in pairs(opts.o.symbols.icons) do
+    symbols_items[#symbols_items + 1] = key
+  end
+
+  symbols_items[#symbols_items + 1] = M.all_kind
+  table.sort(symbols_items)
+
+  return symbols_items
+end
+
+function M.pad_string(s, length)
+  local string_s = tostring(s)
+  return string.format('%s%' .. (length - #string_s) .. 's', string_s, ' ')
+end
+
+local rstrip_whitespace = function(str)
+  str = string.gsub(str, '%s+$', '')
+  return str
+end
+
+local function lstrip_whitespace(str, limit)
+  if limit ~= nil then
+    local num_found = 0
+    while num_found < limit do
+      str = string.gsub(str, '^%s', '')
+      num_found = num_found + 1
+    end
+  else
+    str = string.gsub(str, '^%s+', '')
+  end
+  return str
+end
+
+---@param str string
+---@return string
+function M.strip_whitespace(str)
+  if str then
+    return rstrip_whitespace(lstrip_whitespace(str))
+  end
+  return ''
+end
+
+return M

--- a/lua/outline/sidebar.lua
+++ b/lua/outline/sidebar.lua
@@ -1,3 +1,4 @@
+local Picker = require('outline.pickers')
 local Preview = require('outline.preview')
 local View = require('outline.view')
 local cfg = require('outline.config')
@@ -151,6 +152,7 @@ function Sidebar:setup_keymaps()
     fold_all = { '_set_all_folded', { true } },
     unfold_all = { '_set_all_folded', { false } },
     fold_reset = { '_set_all_folded', {} },
+    filter_symbols = { '_filter_kind_symbols', {} },
     rename_symbol = {
       providers.action, { self, 'rename_symbol', { self } }
     },
@@ -621,6 +623,10 @@ function Sidebar:open(opts)
       self:focus()
     end
   end
+end
+
+function Sidebar:_filter_kind_symbols()
+  Picker.select_symbols(cfg, self)
 end
 
 ---@see outline.close_outline


### PR DESCRIPTION
Hi, I've been using this plugin for a long time — it's been really helpful!
I'd like to suggest to add feature for filtering symbols via a picker (or something similar).

I've created a simple version for fzf-lua, and the default using `vim.ui.select`

https://github.com/user-attachments/assets/fc70491a-7e82-4128-9e4f-9adef8e5de83



Do you think this feature would be a good addition to the plugin?

Let me know what you think!

(Thanks again for this awesome plugin)