### PR TITLE
fix: splitkeep=screen support when jumping the cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Pass a table to the setup call with your configuration options.
 ```lua
 {
   outline_window = {
-    -- Where to open the split window: right/left
+    -- Where to open the outline window: right/left/float
     position = 'right',
     -- The default split commands used are 'topleft vs' and 'botright vs'
     -- depending on `position`. You can change this by providing your own
@@ -185,13 +185,16 @@ Pass a table to the setup call with your configuration options.
     -- outline window. Eg, 'rightbelow vsplit'.
     -- Width can be included (with will override the width setting below):
     -- Eg, `topleft 20vsp` to prevent a flash of windows when resizing.
+    -- Ignored when position = 'float'.
     split_command = nil,
 
     -- Percentage or integer of columns; serves as the base/minimum width
     -- for the outline window (and for auto_width calculations)
+    -- Ignored when position = 'float' (see outline_window.float below).
     width = 25,
     -- When auto_width.enabled = true, 'width' is the minimum window width.
     -- When auto_width.enabled = false, 'width' is the exact/default window width.
+    -- Ignored when position = 'float'.
     auto_width = {
       -- Dynamically resize window width to fit content
       enabled = false,
@@ -203,7 +206,21 @@ Pass a table to the setup call with your configuration options.
     -- Whether width is relative to the total width of nvim
     -- When relative_width = true, this means take 25% of the total
     -- screen width for outline window.
+    -- Ignored when position = 'float'.
     relative_width = true,
+
+    -- Only used when position = 'float'. Ignored otherwise.
+    float = {
+      -- Percentage or integer of columns/lines for the floating window
+      width = 60,
+      height = 80,
+      -- Whether width/height above are a percentage of nvim's screen size
+      relative_width = true,
+      relative_height = true,
+      -- Passed straight to nvim_open_win
+      border = 'rounded',
+      winblend = 0,
+    },
 
     -- Auto close the outline window if goto_location is triggered and not for
     -- peek_location

--- a/lua/outline/config.lua
+++ b/lua/outline/config.lua
@@ -43,6 +43,15 @@ M.defaults = {
       include_symbol_details = false,
     },
     relative_width = true,
+    -- Only used when position = 'float'. Ignored otherwise.
+    float = {
+      width = 60,
+      height = 80,
+      relative_width = true,
+      relative_height = true,
+      border = 'rounded',
+      winblend = 0,
+    },
     wrap = false,
     focus_on_open = true,
     auto_close = false,
@@ -201,6 +210,22 @@ function M.get_split_command()
   else
     return 'botright vs'
   end
+end
+
+---Compute nvim_open_win opts for a centered floating outline window.
+function M.get_float_window_opts()
+  local conf = M.o.outline_window.float
+  local width = conf.relative_width and math.ceil(vim.o.columns * (conf.width / 100)) or conf.width
+  local height = conf.relative_height and math.ceil(vim.o.lines * (conf.height / 100)) or conf.height
+  return {
+    relative = 'editor',
+    width = width,
+    height = height,
+    row = math.floor((vim.o.lines - height) / 2),
+    col = math.floor((vim.o.columns - width) / 2),
+    border = conf.border,
+    style = 'minimal',
+  }
 end
 
 local function table_has_content(t)

--- a/lua/outline/sidebar.lua
+++ b/lua/outline/sidebar.lua
@@ -410,16 +410,17 @@ function Sidebar:__goto_location(change_focus)
   -- XXX: There will be strange problems when using `nvim_buf_set_mark()`.
   vim.fn.win_execute(self.code.win, "normal! m'")
 
+  -- Temporarily override splitkeep so that cursor movement and window
+  -- switching don't fight over the viewport position.
+  local saved_splitkeep = vim.o.splitkeep
+  vim.o.splitkeep = 'cursor'
+
   vim.api.nvim_win_set_cursor(self.code.win, { node.line + 1, node.character })
 
   if cfg.o.outline_window.center_on_jump then
     vim.fn.win_execute(self.code.win, 'normal! zz')
   else
-    -- Ensure cursor is visible in code window. Without this,
-    -- splitkeep="screen" can prevent the viewport from scrolling
-    -- to reveal the new cursor position.
     vim.fn.win_execute(self.code.win, 'normal! zv')
-    vim.fn.win_execute(self.code.win, 'redraw')
   end
 
   utils.flash_highlight(
@@ -432,6 +433,8 @@ function Sidebar:__goto_location(change_focus)
   if change_focus then
     vim.fn.win_gotoid(self.code.win)
   end
+
+  vim.o.splitkeep = saved_splitkeep
 end
 
 ---Wraps __goto_location and handles auto_close.

--- a/lua/outline/sidebar.lua
+++ b/lua/outline/sidebar.lua
@@ -414,6 +414,12 @@ function Sidebar:__goto_location(change_focus)
 
   if cfg.o.outline_window.center_on_jump then
     vim.fn.win_execute(self.code.win, 'normal! zz')
+  else
+    -- Ensure cursor is visible in code window. Without this,
+    -- splitkeep="screen" can prevent the viewport from scrolling
+    -- to reveal the new cursor position.
+    vim.fn.win_execute(self.code.win, 'normal! zv')
+    vim.fn.win_execute(self.code.win, 'redraw')
   end
 
   utils.flash_highlight(

--- a/lua/outline/sidebar.lua
+++ b/lua/outline/sidebar.lua
@@ -442,7 +442,10 @@ end
 ---@param change_focus boolean
 function Sidebar:_goto_location(change_focus)
   self:__goto_location(change_focus)
-  if change_focus and cfg.o.outline_window.auto_close then
+  -- Floating outline always closes on jump: it overlays the code, so there's
+  -- nothing to keep it open for once focus moves (unlike a sidebar).
+  local should_close = cfg.o.outline_window.auto_close or cfg.o.outline_window.position == 'float'
+  if change_focus and should_close then
     self:close()
   end
 end
@@ -704,8 +707,13 @@ function Sidebar:has_provider()
 end
 
 function Sidebar:update_width()
-  -- exit early if view is closed or dynamic changing is disabled
-  if not self.view:is_open() or not cfg.o.outline_window.auto_width.enabled then
+  -- exit early if view is closed, dynamic changing is disabled, or window is
+  -- floating (auto_width assumes a split; recentering a float isn't handled)
+  if
+    not self.view:is_open()
+    or not cfg.o.outline_window.auto_width.enabled
+    or cfg.o.outline_window.position == 'float'
+  then
     return
   end
 

--- a/lua/outline/view.lua
+++ b/lua/outline/view.lua
@@ -28,17 +28,27 @@ function View:setup_view(split_command)
   utils.buf_set_option(self.buf, 'buftype', 'nofile')
   utils.buf_set_option(self.buf, 'modifiable', false)
 
-  -- create a split
-  vim.cmd(split_command)
+  local is_float = cfg.o.outline_window.position == 'float'
 
-  -- get current (outline) window and attach our buffer to it
-  self.win = vim.api.nvim_get_current_win()
-  vim.api.nvim_win_set_buf(self.win, self.buf)
+  if is_float then
+    self.win = vim.api.nvim_open_win(self.buf, true, cfg.get_float_window_opts())
+    local winblend = cfg.o.outline_window.float.winblend
+    if winblend > 0 then
+      utils.win_set_option(self.win, 'winblend', winblend)
+    end
+  else
+    -- create a split
+    vim.cmd(split_command)
 
-  -- resize if split_command not specify width like "25vsplit"
-  if split_command:match('%d+') == nil then
-    -- resize to a % of the current window size
-    vim.cmd('vertical resize ' .. cfg.o.outline_window.width)
+    -- get current (outline) window and attach our buffer to it
+    self.win = vim.api.nvim_get_current_win()
+    vim.api.nvim_win_set_buf(self.win, self.buf)
+
+    -- resize if split_command not specify width like "25vsplit"
+    if split_command:match('%d+') == nil then
+      -- resize to a % of the current window size
+      vim.cmd('vertical resize ' .. cfg.o.outline_window.width)
+    end
   end
 
   -- window stuff


### PR DESCRIPTION
When `splitkeep="screen"` is set; The first `<CR>` doesn't move the cursor to the selected node. This fixes this by a `za` and a redraw; I also think the whole if-esle statement could be replaced by a single `zvzz` call, but didn't want to be intrusive.

A minimal init script to reproduce the bug and check the fix:
```lua
-- Minimal init.lua to reproduce outline.nvim splitkeep bug
-- Usage: nvim -u /tmp/outline-test/init.lua some_file.json

local lazypath = "/tmp/outline-test/lazy"
vim.opt.runtimepath:prepend(lazypath .. "/lazy.nvim")
if not vim.uv.fs_stat(lazypath .. "/lazy.nvim") then
  vim.fn.system({
    "git", "clone", "--filter=blob:none",
    "https://github.com/folke/lazy.nvim.git",
    lazypath .. "/lazy.nvim",
  })
end

vim.g.mapleader = " "
vim.opt.splitkeep = "screen"

require("lazy").setup({
  { "mason-org/mason.nvim", opts = { install_root_dir = "/tmp/outline-test/mason" } },
  {
    "mason-org/mason-lspconfig.nvim",
    dependencies = { "mason.nvim", "nvim-lspconfig" },
    opts = { ensure_installed = { "jsonls" }, automatic_enable = true },
  },
  { "neovim/nvim-lspconfig", config = function() vim.lsp.config("jsonls", {}) end },
  {
    "hedyhli/outline.nvim",
    cmd = { "Outline", "OutlineOpen" },
    keys = { { "<leader>nn", "<cmd>Outline<cr>", desc = "Outline" } },
    opts = {
      outline_window = { position = "left" },
      keymaps = { goto_location = '<CR>', goto_and_close = '<S-CR>' },
    },
  },
}, { root = lazypath })
```